### PR TITLE
fix for successfull connection detection

### DIFF
--- a/lib/core/ros.dart
+++ b/lib/core/ros.dart
@@ -109,6 +109,8 @@ class Ros {
       if (e is WebSocketChannelException || e is SocketException) {
         status = Status.errored;
         _statusController.add(status);
+      } else {
+        rethrow;
       }
     }
   }

--- a/lib/core/ros.dart
+++ b/lib/core/ros.dart
@@ -33,7 +33,7 @@ class Ros {
   /// Initializes the [_statusController] as a broadcast.
   /// The [url] of the ROS node can be optionally specified at this point.
   Ros({this.url}) {
-    _statusController = StreamController<Status>.broadcast();
+    _statusController = StreamController<(Status status, String? reason)>.broadcast();
   }
 
   /// The url of ROS node running the rosbridge server.
@@ -64,55 +64,146 @@ class Ros {
   late Stream<Map<String, dynamic>> stream;
 
   /// The controller to update subscribers on the state of the connection.
-  late StreamController<Status> _statusController;
+  late StreamController<(Status status, String? reason)> _statusController;
 
   /// Subscribable stream to listen for connection status changes.
-  Stream<Status> get statusStream => _statusController.stream;
+  Stream<(Status status, String? reason)> get statusStream => _statusController.stream;
 
   /// Status variable that can be used when not interested in getting live updates.
   Status status = Status.none;
 
+  void _changeStatus(Status status, [String? reason]) {
+    this.status = status;
+    _statusController.add((status, reason));
+  }
+
   /// Connect to the ROS node, the [url] can override what was provided in the constructor.
-  void connect({dynamic url}) {
+  void connect({dynamic url}) async {
     this.url = url ?? this.url;
     url ??= this.url;
 
-    status = Status.connecting;
-    _statusController.add(status);
+    _changeStatus(Status.connecting);
 
-    try {
-      // Initialize the connection to the ROS node with a Websocket.
-      WebSocket.connect(url).then((socket) {
-        // Convert the WebSocket to a WebSocketChannel.
-        _channel = IOWebSocketChannel(socket);
+    // try {
+    //   _channel = WebSocketChannel.connect(Uri.parse(url));
+    // } catch (error) {
+    //   _changeStatus(Status.errored, error.toString());
+    // }
+
+    // Uri uri = Uri.parse('ws://' + host + ':' + port.toString());
+
+    // timeout based on https://github.com/dart-lang/web_socket_channel/issues/61
+    final httpClient = HttpClient();
+    httpClient.connectionTimeout = const Duration(seconds: 15);
+    await runZonedGuarded<Future<void>>(() async {
+      WebSocket.connect(
+        url,
+        customClient: httpClient,
+      ).then((ws) {
+        _channel = IOWebSocketChannel(ws);
+        _changeStatus(Status.connected);
+
         stream = _channel.stream.asBroadcastStream().map((raw) => json.decode(raw));
 
-        // Update the connection status.
-        status = Status.connected;
-        _statusController.add(status);
-
         // Listen for messages on the connection to update the status.
-        _channelListener = stream.listen((data) {
-          //print('INCOMING: $data');
-        }, onError: (error) {
-          status = Status.errored;
-          _statusController.add(status);
-        }, onDone: () {
-          status = Status.closed;
-          _statusController.add(status);
-        });
-      }).catchError((e) {
-        status = Status.errored;
-        _statusController.add(status);
+        _channelListener = stream.listen(
+          (data) {
+            //print('INCOMING: $data');
+          },
+          onError: (error) {
+            _changeStatus(Status.errored, error.toString());
+          },
+          onDone: () {
+            _changeStatus(Status.closed);
+          },
+          cancelOnError: true,
+        );
+      }).onError((error, stackTrace) {
+        if (error is TimeoutException) {
+          _changeStatus(Status.errored, "connection timed out");
+        } else if (error is SocketException) {
+          if (error.message.substring(0, 25) == "HTTP connection timed out") {
+            _changeStatus(Status.errored, "connection timed out");
+          } else {
+            _changeStatus(Status.errored, error.message);
+          }
+        } else {
+          _changeStatus(Status.errored, error.toString());
+        }
       });
-    } catch (e) {
-      if (e is WebSocketChannelException || e is SocketException) {
-        status = Status.errored;
-        _statusController.add(status);
-      } else {
-        rethrow;
-      }
-    }
+    }, (error, stack) async {
+      _changeStatus(Status.errored, error.toString());
+    });
+
+    // try {
+    //   await runZonedGuarded<Future<void>>(() async {
+    //     try {
+    //       WebSocket.connect(url).timeout(const Duration(seconds: 10)).then((ws) {
+    //         _channel = IOWebSocketChannel(ws);
+
+    //         stream = _channel.stream.asBroadcastStream().map((raw) => json.decode(raw));
+
+    //         // Update the connection status.
+    //         _changeStatus(Status.connected);
+
+    //         // Listen for messages on the connection to update the status.
+    //         _channelListener = stream.listen((data) {
+    //           //print('INCOMING: $data');
+    //         }, onError: (error) {
+    //           _changeStatus(Status.errored, error.toString());
+    //         }, onDone: () {
+    //           _changeStatus(Status.closed);
+    //         });
+    //       });
+    //     } catch (error) {
+    //       _changeStatus(Status.errored, error.toString());
+    //     }
+    //   }, (error, stack) async {
+    //     if (error is TimeoutException) {
+    //       _changeStatus(Status.errored, "connection timed out");
+    //     } else {
+    //       _changeStatus(Status.errored, error.toString());
+    //     }
+
+    //     await _channel.ready;
+    //     _channel.sink.close();
+    //   });
+    // } catch (error) {
+    //   _changeStatus(Status.errored, error.toString());
+    //   return;
+    // }
+
+    // try {
+    //   // Initialize the connection to the ROS node with a Websocket.
+    //   WebSocket.connect(url).then((socket) {
+    //     // Convert the WebSocket to a WebSocketChannel.
+    //     _channel = IOWebSocketChannel(socket);
+    //     stream = _channel.stream.asBroadcastStream().map((raw) => json.decode(raw));
+
+    //     // Update the connection status.
+    //     _changeStatus(Status.connected);
+
+    //     // Listen for messages on the connection to update the status.
+    //     _channelListener = stream.listen((data) {
+    //       //print('INCOMING: $data');
+    //     }, onError: (error) {
+    //       _changeStatus(Status.errored, error);
+    //     }, onDone: () {
+    //       _changeStatus(Status.closed);
+    //     });
+    //   }, onError: (e) {
+    //     _changeStatus(Status.errored, e.toString());
+    //   }).catchError((e) {
+    //     _changeStatus(Status.errored, e.toString());
+    //   });
+    // } catch (e) {
+    //   if (e is WebSocketChannelException || e is SocketException) {
+    //     _changeStatus(Status.errored, e.toString());
+    //   } else {
+    //     print("rethrowing");
+    //     rethrow;
+    //   }
+    // }
   }
 
   /// Close the connection to the ROS node, an exit [code] and [reason] can
@@ -123,8 +214,7 @@ class Ros {
     await _channel.sink.close(code, reason);
 
     /// Update the connection status.
-    _statusController.add(Status.closed);
-    status = Status.closed;
+    _changeStatus(Status.closed);
   }
 
   /// Send a [message] to the ROS node

--- a/lib/core/service.dart
+++ b/lib/core/service.dart
@@ -5,8 +5,7 @@ import 'ros.dart';
 import 'request.dart';
 
 // Receiver function to handle requests when the service is advertising.
-typedef ServiceHandler = Future<Map<String, dynamic>>? Function(
-    Map<String, dynamic> args);
+typedef ServiceHandler = Future<Map<String, dynamic>>? Function(Map<String, dynamic> args);
 
 /// Wrapper to interact with ROS services.
 class Service {
@@ -34,15 +33,14 @@ class Service {
   StreamSubscription? listener;
 
   /// Call the service with a request ([req]).
-  Future call(dynamic req) {
+  Future call(Map<String, dynamic> req) {
     // The service can't be called if it's currently advertising.
     if (isAdvertised) return Future.value(false);
     // Set up the response receiver by filtering data from the ROS node by the ID generated.
     final callId = ros.requestServiceCaller(name);
-    final receiver = ros.stream.where((message) => message['id'] == callId).map(
-        (Map<String, dynamic> message) => message['result'] == null
-            ? Future.error(message['values']!)
-            : Future.value(message['values']));
+    final receiver = ros.stream
+        .where((message) => message['id'] == callId)
+        .map((Map<String, dynamic> message) => message['result'] == null ? Future.error(message['values']!) : Future.value(message['values']));
     // Wait for the receiver to receive a single response and then return.
     final completer = Completer();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ repository: https://github.com/tmtong/roslibdart
 version: 0.0.1-dev+3
 
 environment:
-  sdk: ">=2.16.0-134.5.beta <3.0.0"
+  sdk: '^3.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
The old implementation always set the status to `Status.connected` when a new connection attempt was performed.
Even if the server was not reachable the `_statusController` informed all listeners about the successfull connection.
Just to fire a `Status.errored` event a few moments later.

My implementation waits until the connection was actually established.